### PR TITLE
configure daily riddle hour via appsettings

### DIFF
--- a/Guessnica-backend/Controllers/GameController.cs
+++ b/Guessnica-backend/Controllers/GameController.cs
@@ -13,10 +13,12 @@ using System.Security.Claims;
 public class GameController : ControllerBase
 {
     private readonly IGameService _game;
+    private readonly IConfiguration _config;
 
-    public GameController(IGameService game)
+    public GameController(IGameService game, IConfiguration config)
     {
         _game = game;
+        _config = config;
     }
 
     [HttpGet("daily")]
@@ -29,7 +31,9 @@ public class GameController : ControllerBase
         if (userId == null)
             return Unauthorized();
 
-        var ur = await _game.GetDailyRiddleAsync(userId);
+        var dailyHourUtc = _config.GetValue<int>("Game:DailyRiddleHourUtc", 0);
+
+        var ur = await _game.GetDailyRiddleAsync(userId, dailyHourUtc);
 
         return Ok(new DailyRiddleResponseDto
         {

--- a/Guessnica-backend/appsettings.json
+++ b/Guessnica-backend/appsettings.json
@@ -28,5 +28,8 @@
       "AppId": "1462949434810709",
       "AppSecret": "e048d733a2a91e4101ffb392e456f8ff"
     }
+  },
+  "Game": {
+    "DailyRiddleHourUtc": 0
   }
 }


### PR DESCRIPTION
Daily riddle reset hour is now configurable via Game:DailyRiddleHourUtc in appsettings.json (UTC).
Implemented this as a config option to avoid extra frontend work close to the presentation deadline.